### PR TITLE
Fixed navigation for substance abuse scenario 2

### DIFF
--- a/branching.py
+++ b/branching.py
@@ -79,8 +79,8 @@ async def sa_scenario_branching(query):
     # 4.1 Scenario 1: Underage drinking at a party
     if query.data == 'Party':
         await query.edit_message_text(messages.sa_scenario_1, reply_markup=keyboards.sa_s1_keyboard())
-    # 4.2 Scenario 2: Drug addiction at school
-    elif query.data == 'School':
+    # 4.2 Scenario 2: Drug addiction at a friend's home
+    elif query.data == options.sa_friends_home:
         await query.edit_message_text(messages.sa_scenario_2, reply_markup=keyboards.sa_s2_keyboard())
 
      
@@ -225,16 +225,16 @@ async def sa1_intervention_branching(query):
         await intervention_end_redirect(query, messages.sa1_perspective_taking)
 
 async def sa2_intervention_branching(query):
-    if query.data == callbacks.sa2_distract:
-        await intervention_end_redirect(query, messages.sa2_distract)
-    elif query.data == callbacks.sa2_delegate:
-        await intervention_end_redirect(query, messages.sa2_delegate)
-    elif query.data == callbacks.sa2_document:
-        await intervention_end_redirect(query, messages.sa2_document)
-    elif query.data == callbacks.sa2_delay:
-        await intervention_end_redirect(query, messages.sa2_delay)
-    elif query.data == callbacks.sa2_direct:
-        await intervention_end_redirect(query, messages.sa2_direct)
+    if query.data == callbacks.sa2_care:
+        await intervention_end_redirect(query, messages.sa2_care)
+    elif query.data == callbacks.sa2_see:
+        await intervention_end_redirect(query, messages.sa2_see)
+    elif query.data == callbacks.sa2_feel:
+        await intervention_end_redirect(query, messages.sa2_feel)
+    elif query.data == callbacks.sa2_want:
+        await intervention_end_redirect(query, messages.sa2_want)
+    elif query.data == callbacks.sa2_will:
+        await intervention_end_redirect(query, messages.sa2_will)
 
 async def sr1_intervention_branching(query):
     if query.data == callbacks.sr1_care:

--- a/callbacks.py
+++ b/callbacks.py
@@ -75,7 +75,7 @@ sa1_callbacks = [
 ]
 
 
-# 4.2 Scenario 2: Drug addiction at school
+# 4.2 Scenario 2: Drug addiction at a friend's home
 sa2_care = 'sa2_care'
 sa2_see = 'sa2_see'
 sa2_feel = 'sa2_feel'

--- a/options.py
+++ b/options.py
@@ -24,8 +24,8 @@ dv_keyboard = [dv_apartment, dv_livingroom]
 
 # Substance abuse introduction options
 sa_party = 'Party'
-sa_school = 'School'
-sa_keyboard = [sa_party, sa_school]
+sa_friends_home = "Friend's home"
+sa_keyboard = [sa_party, sa_friends_home]
 
 # Suicide risk introduction options
 sr_cafeteria = 'Cafeteria'


### PR DESCRIPTION
Resolved #10.

This issue appeared for two reasons:
1. The branching for substance abuse scenario 2 wrongly reflected variable names that corresponded to the 5 core questions instead of the 5 point formula.
2. Scenarios 2.2 (sexual harassment - unsolicited messages at school) and 4.2 (substance abuse - drug addiction in school) are both situated in school. As a result, both of them had the same callback `School`.

Since both scenarios had the `School` callback in common, the bot erroneously entered the sexual harassment branch instead of the substance abuse branch.

To fix this issue,
1. The variable names were corrected.
2. The location of 4.2 was changed to "Friend's home" 